### PR TITLE
Support send_time in ChatMessage

### DIFF
--- a/src/chat/entities.rs
+++ b/src/chat/entities.rs
@@ -174,6 +174,9 @@ pub struct ChatMessage {
     /// User ID of the sender. Maybe be `None` for `Event` message types, possibly others
     pub sender_id: Option<i64>,
 
+    /// Time that the message was sent
+    pub send_time: u32,
+
     /// Extra info of chat
     #[serde(default)]
     pub content_data: HashMap<String, serde_json::Value>,

--- a/src/chat/entities.rs
+++ b/src/chat/entities.rs
@@ -1,5 +1,7 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_repr::*;
+use serde_with::{serde_as, TimestampSeconds};
 use std::collections::HashMap;
 
 /// Holds a chat token obtained via the api to authenticate
@@ -137,6 +139,7 @@ pub enum ChatMessageType {
 }
 
 /// A single chat message
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ChatMessage {
     /// Type of chat message.
@@ -175,7 +178,8 @@ pub struct ChatMessage {
     pub sender_id: Option<i64>,
 
     /// Time that the message was sent
-    pub send_time: u32,
+    #[serde_as(as = "TimestampSeconds<i64>")]
+    pub send_time: DateTime<Utc>,
 
     /// Extra info of chat
     #[serde(default)]


### PR DESCRIPTION
Per the Trovo changelog: https://developer.trovo.live/docs/Change%20Log.html on January 24th 2022, send_time was added to the CHAT messages. 

Trovo appears to re-send the last 5 messages received when a stream starts/ends, to avoid showing these messages as if they're new, I was to be able to utilize send_time to keep track of timestamps. I've tested this change as a local crate against changes for https://github.com/exlted/StreamCore/issues/22 and as far as I could tell it was fully working. 

If there's something obvious that I missed, I'd be happy to finish the changes if you'd point them out. Thanks!